### PR TITLE
Add link permit system

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -142,6 +142,16 @@ async function initDb() {
   `);
 
   await dbRun(`
+    CREATE TABLE IF NOT EXISTS link_permits (
+      guild_id   VARCHAR(32) NOT NULL,
+      user_id    VARCHAR(32) NOT NULL,
+      granted_by VARCHAR(32) NOT NULL,
+      expires_at BIGINT NOT NULL,
+      PRIMARY KEY (guild_id, user_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+  `);
+
+  await dbRun(`
     CREATE TABLE IF NOT EXISTS xp_progress (
       guild_id        VARCHAR(32) NOT NULL,
       user_id         VARCHAR(32) NOT NULL,

--- a/src/discord/permits.js
+++ b/src/discord/permits.js
@@ -1,0 +1,49 @@
+const { PermissionsBitField } = require('discord.js');
+const { dbRun, dbGet } = require('../db');
+const { log } = require('../logger');
+
+const LINK_REGEX = /(https?:\/\/|www\.)[^\s<]+/i;
+const PERMIT_DURATION_MS = 60 * 60 * 1000; // 1 hour
+
+function isStaff(member) {
+  if (!member) return false;
+  if (member.permissions?.has(PermissionsBitField.Flags.Administrator)) return true;
+  return member.permissions?.has(PermissionsBitField.Flags.ManageMessages);
+}
+
+function messageHasLink(message) {
+  if (!message || !message.content) return false;
+  return LINK_REGEX.test(message.content);
+}
+
+async function grantLinkPermit(guildId, userId, grantedBy, durationMs = PERMIT_DURATION_MS) {
+  const expiresAt = Date.now() + durationMs;
+  await dbRun(
+    'INSERT INTO link_permits (guild_id, user_id, granted_by, expires_at) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE granted_by=VALUES(granted_by), expires_at=VALUES(expires_at)',
+    [guildId, userId, grantedBy, expiresAt]
+  );
+  log.tag('PERMIT').info(`guild=${guildId} user=${userId} grantedBy=${grantedBy} expiresAt=${expiresAt}`);
+  return expiresAt;
+}
+
+async function hasActivePermit(guildId, userId) {
+  if (!guildId || !userId) return false;
+  const row = await dbGet('SELECT expires_at FROM link_permits WHERE guild_id=? AND user_id=?', [guildId, userId]);
+  if (!row) return false;
+  if (Number(row.expires_at) > Date.now()) return true;
+  await dbRun('DELETE FROM link_permits WHERE guild_id=? AND user_id=?', [guildId, userId]);
+  return false;
+}
+
+async function revokePermit(guildId, userId) {
+  await dbRun('DELETE FROM link_permits WHERE guild_id=? AND user_id=?', [guildId, userId]);
+}
+
+module.exports = {
+  grantLinkPermit,
+  hasActivePermit,
+  isStaff,
+  messageHasLink,
+  revokePermit,
+  PERMIT_DURATION_MS,
+};


### PR DESCRIPTION
## Summary
- add a staff-only `/permit` slash command that grants one hour of link posting access
- persist link permits in a new database table and helper module
- automatically delete unpermitted links while allowing staff to post freely

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e63f65caa483269f398d751e1521e4