### PR TITLE
Exclude bots from member logging

### DIFF
--- a/src/discord/logging.js
+++ b/src/discord/logging.js
@@ -59,6 +59,7 @@ function buildUserFooter(user, extra, fallbackId) {
 
 async function handleMemberAdd(member) {
   const user = member.user ?? null;
+  if (user?.bot) return;
   await dispatchLog(member.guild, () => {
     const joinedAt = member.joinedAt ? new Date(member.joinedAt) : new Date();
     const embed = baseEmbed()
@@ -99,6 +100,7 @@ async function handleMemberAdd(member) {
 
 async function handleMemberRemove(member) {
   const user = member.user ?? null;
+  if (user?.bot) return;
   await dispatchLog(member.guild, () => {
     const embed = baseEmbed()
       .setColor(Colors.Red)


### PR DESCRIPTION
## Summary
- skip logging join/leave events when the member is a bot so the logging channel only tracks humans

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e644f5c1fc83269574be5d5cba3ece