### PR TITLE
Document env flag value ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,16 @@ Private automation bot for the Paradise Discord server. It connects member Steam
 ## ⚙️ Environment flags
 All configuration lives in `.env`. The `example.env` file documents every supported option. Highlights:
 
-| Area | Key flags |
-| --- | --- |
-| Discord auth | `DISCORD_TOKEN`, `DISCORD_CLIENT_ID`, `DEV_GUILD_ID` |
-| Database | `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASS`, `DB_NAME` |
-| Steam polling | `POLL_SECONDS`, `OWNED_POLL_SECONDS`, `NOWPLAYING_POLL_SECONDS`, `LEADERBOARD_POLL_SECONDS`, `SALES_POLL_SECONDS`, `MAX_CONCURRENCY` |
-| Sales board | `SALES_REGION_CC`, `SALES_PAGE_SIZE`, `SALES_PRECACHE_PAGES`, `SALES_PRECACHE_PREV_PAGES`, `SALES_PAGE_TTL_MS`, `SALES_MAX_PAGES_CACHE`, `SALES_FULL_WARMER_ENABLED` |
-| GitHub announcer | `GITHUB_ANNOUNCER_ENABLED`, `GITHUB_OWNER`, `GITHUB_REPO`, `GITHUB_BRANCH`, `GITHUB_POLL_SECONDS`, `GITHUB_MAX_CATCHUP`, `GITHUB_ANNOUNCE_ON_START`, `GITHUB_TOKEN`, `GITHUB_EMBED_COLOR` |
-| Milestones & rarity | `PLAYTIME_MARKS`, `ACHIEVEMENT_MARKS`, `RARE_PCT`, `RARITY_TTL_HOURS` |
-| Moderation | `MODERATION_BANNED_TERMS` (comma-separated extra phrases) |
-| Logging | `DEBUG_LEVEL`, `DEBUG_HTTP`, `DEBUG_SQL`, `STEAM_EMBED_COLOR` |
+| Area | Key flags | Possible values / format |
+| --- | --- | --- |
+| Discord auth | `DISCORD_TOKEN`<br>`DISCORD_CLIENT_ID`<br>`DEV_GUILD_ID` | Discord bot token string.<br>Discord application (client) ID snowflake.<br>Optional guild snowflake for dev-only command registration. |
+| Database | `DB_HOST`<br>`DB_PORT`<br>`DB_USER`<br>`DB_PASS`<br>`DB_NAME` | Hostname or IP (e.g., `127.0.0.1`).<br>Port number (default `3306`).<br>Database username.<br>Database password.<br>Database/schema name. |
+| Steam polling | `POLL_SECONDS`<br>`OWNED_POLL_SECONDS`<br>`NOWPLAYING_POLL_SECONDS`<br>`LEADERBOARD_POLL_SECONDS`<br>`SALES_POLL_SECONDS`<br>`MAX_CONCURRENCY` | Integer seconds between polls (defaults: `300`, `3600`, `120`, `300`, `86400`).<br>Maximum concurrent Steam API calls (integer, default `4`). |
+| Sales board | `SALES_SORT_BY`<br>`SALES_REGION_CC`<br>`SALES_PAGE_SIZE`<br>`SALES_PAGE_TTL_MS`<br>`SALES_EXTEND_TTL_ON_HIT`<br>`SALES_PRECACHE_PAGES`<br>`SALES_PRECACHE_PREV_PAGES`<br>`SALES_PREWARM_SPACING_MS`<br>`SALES_FULL_WARMER_ENABLED`<br>`SALES_FULL_WARMER_DELAY_MS`<br>`SALES_FULL_WARMER_SPACING_MS`<br>`SALES_MAX_PAGES_CACHE` | Steam sort key (e.g., `Discount_DESC`).<br>ISO 3166-1 alpha-2 country code (e.g., `US`).<br>Results per page (integer, default `10`).<br>Cache TTL in milliseconds (default `1200000`).<br>`true`/`false` toggle for TTL extension.<br>Number of future pages to cache (integer, default `3`).<br>Number of previous pages to cache (integer, default `1`).<br>Delay between prewarm requests in ms (integer, default `200`).<br>`true`/`false` toggle to warm every page.<br>Delay before full warmer in ms (integer, default `15000`).<br>Spacing between full warmer requests in ms (integer, default `1200`).<br>Maximum cached pages (integer, default `600`). |
+| GitHub announcer | `GITHUB_ANNOUNCER_ENABLED`<br>`GITHUB_OWNER`<br>`GITHUB_REPO`<br>`GITHUB_BRANCH`<br>`GITHUB_TOKEN`<br>`GITHUB_POLL_SECONDS`<br>`GITHUB_MAX_CATCHUP`<br>`GITHUB_ANNOUNCE_ON_START`<br>`GITHUB_EMBED_COLOR` | `true`/`false` toggle.<br>Repository owner/org name.<br>Repository name.<br>Branch name (e.g., `main`).<br>GitHub token (optional, supports fine-grained PATs).<br>Integer seconds between polls (default `60`).<br>Maximum missed commits to announce per poll (integer, default `5`).<br>`true`/`false` toggle to post immediately on boot.<br>Hex color string (e.g., `#24292E`). |
+| Milestones & rarity | `PLAYTIME_MARKS`<br>`ACHIEVEMENT_MARKS`<br>`RARE_PCT`<br>`RARITY_TTL_HOURS` | Comma-separated minute thresholds (e.g., `10,25,50,100`).<br>Comma-separated achievement counts (e.g., `25,50,75,100`).<br>Percent threshold for rarity callouts (floating number, default `1.0`).<br>Hours before rarity cache refresh (integer, default `24`). |
+| Moderation | `MODERATION_BANNED_TERMS` | Comma-separated additional phrases to block (case-insensitive). |
+| Logging & embeds | `DEBUG_LEVEL`<br>`DEBUG_HTTP`<br>`DEBUG_SQL`<br>`STEAM_EMBED_COLOR` | One of `silent`, `error`, `warn`, `info`, `debug`, `trace` (default `info`).<br>`0`/`1` integers to toggle HTTP tracing.<br>`0`/`1` integers to toggle SQL tracing.<br>Hex color string (e.g., `#171A21`). |
 
 Restart the bot whenever you change `.env`; modules read configuration at boot.
 


### PR DESCRIPTION
## Summary
- expand the environment flag table in the README with a "Possible values / format" column
- document boolean, numeric, and enumerated options pulled from example.env to clarify configuration choices

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e647c125bc832691df3d179f4a908c