### PR TITLE
Redact GitHub token from logs

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -7,7 +7,12 @@ const DEBUG_SQL  = !!Number(process.env.DEBUG_SQL  || 0);
 const redact = (v) => {
   if (!v) return v;
   let s = String(v);
-  const secrets = [process.env.DISCORD_TOKEN, process.env.STEAM_API_KEY, process.env.DB_PASS];
+  const secrets = [
+    process.env.DISCORD_TOKEN,
+    process.env.STEAM_API_KEY,
+    process.env.DB_PASS,
+    process.env.GITHUB_TOKEN,
+  ];
   for (const sec of secrets) if (sec) s = s.split(sec).join('••••••••');
   return s;
 };


### PR DESCRIPTION
## Summary
- add the GitHub personal access token to the list of redacted secrets in the logger

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e649c00910832682c9798c19ca12d0