### PR TITLE
Simplify GitHub commit embed formatting

### DIFF
--- a/src/github/announcer.js
+++ b/src/github/announcer.js
@@ -84,42 +84,40 @@ function firstLine(text) {
   return String(text).split(/\r?\n/, 1)[0];
 }
 
-function summarizeFiles(files = []) {
-  if (!Array.isArray(files) || files.length === 0) return 'No file changes listed.';
-  const snippets = files.slice(0, 5).map((file) => {
-    const indicator = file.status === 'removed' ? '➖' : file.status === 'added' ? '➕' : '✏️';
-    return `${indicator} ${file.filename}`;
-  });
-  if (files.length > 5) snippets.push(`…and ${files.length - 5} more`);
-  return snippets.join('\n');
-}
-
 function buildEmbed(detail) {
   const commit = detail.commit || {};
   const author = commit.author || {};
-  const stats = detail.stats || {};
   const commitDate = commit?.author?.date || commit?.committer?.date || null;
   const embed = new EmbedBuilder()
     .setColor(GITHUB_EMBED_COLOR)
-    .setTitle(`${firstLine(commit.message)} (${shortSha(detail.sha)})`)
+    .setTitle(firstLine(commit.message))
     .setURL(detail.html_url)
-    .setDescription(commit.message || '—')
     .setTimestamp(commitDate ? new Date(commitDate) : new Date());
 
-  if (author.name) embed.addFields({ name: 'Author', value: author.name, inline: true });
-  if (commitDate) embed.addFields({ name: 'Committed', value: discordTime(new Date(commitDate), 'R'), inline: true });
-  embed.addFields(
-    { name: 'Additions', value: String(stats.additions ?? 0), inline: true },
-    { name: 'Deletions', value: String(stats.deletions ?? 0), inline: true },
-    { name: 'Files Changed', value: String(stats.total ?? detail.files?.length ?? 0), inline: true },
-  );
+  if (repoSlug) {
+    embed.setAuthor({ name: repoSlug, url: `https://github.com/${repoSlug}` });
+  }
 
-  const summary = summarizeFiles(detail.files);
-  if (summary) embed.addFields({ name: 'Files', value: summary });
+  const descriptionParts = [];
+
+  const shaLink = detail.html_url ? `[${shortSha(detail.sha)}](${detail.html_url})` : shortSha(detail.sha);
+  if (shaLink) descriptionParts.push(shaLink);
+
+  if (commitDate) descriptionParts.push(discordTime(new Date(commitDate), 'R'));
+
+  const displayAuthor = detail.author?.login || author.name || author.email || null;
+  if (displayAuthor) {
+    const authorLink = detail.author?.html_url ? `[${displayAuthor}](${detail.author.html_url})` : displayAuthor;
+    descriptionParts.push(`by ${authorLink}`);
+  }
+
+  if (descriptionParts.length) {
+    embed.setDescription(descriptionParts.join(' • '));
+  }
 
   if (detail.author?.avatar_url) embed.setThumbnail(detail.author.avatar_url);
 
-  embed.setFooter({ text: `GitHub • ${repoSlug}` });
+  embed.setFooter({ text: 'GitHub' });
   return embed;
 }
 


### PR DESCRIPTION
## Summary
- simplify the GitHub commit announcer embed to show only the repository, commit link, author, and timestamp
- remove the file and statistics fields to better match a streamlined announcement style

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e6512d94fc83268a687a53d98f5295