### PR TITLE
Limit sales embed to 10 items

### DIFF
--- a/src/sales/index.js
+++ b/src/sales/index.js
@@ -250,7 +250,7 @@ async function getPageData(cc, pageIndex) {
     const start = pageIndex * SALES_PAGE_SIZE;
     const t = time(`SALES:fetch:${cc}:${pageIndex}`);
     const data = await fetchSearchJson(cc, start, SALES_PAGE_SIZE);
-    let items = parseSearchHtml(data.results_html || '');
+    let items = parseSearchHtml(data.results_html || '').slice(0, SALES_PAGE_SIZE);
 
     const rawTotal = Number(data.total_count);
     let totalPages;


### PR DESCRIPTION
## Summary
- trim parsed sale items to the configured page size before building the embed
- keep fallback HTML parsing constrained to the same maximum count

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6731f4bd083269bdaf7948f6ecbc7