### PR TITLE
Add configurable overrides for Steam app names

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ All configuration is sourced from environment variables. Highlights:
 | GitHub announcer | `GITHUB_ANNOUNCER_ENABLED`, `GITHUB_OWNER`, `GITHUB_REPO`, `GITHUB_BRANCH`, `GITHUB_TOKEN`, `GITHUB_POLL_SECONDS`, `GITHUB_MAX_CATCHUP`, `GITHUB_ANNOUNCE_ON_START`, `GITHUB_EMBED_COLOR`, `GITHUB_WEBHOOK_ENABLED`, `GITHUB_WEBHOOK_PORT`, `GITHUB_WEBHOOK_PATH`, `GITHUB_WEBHOOK_SECRET` | Toggle polling/webhooks and point at the repository to mirror. Optional token boosts rate limits and enables private repo access. |
 | Moderation | `MODERATION_BANNED_TERMS` | Comma-separated list of extra phrases to block in addition to the default hate-speech list. |
 | Logging | `DEBUG_LEVEL`, `DEBUG_HTTP`, `DEBUG_SQL`, `STEAM_EMBED_COLOR` | Adjust log verbosity and embed colours; HTTP/SQL tracing aids debugging. |
+| Steam naming overrides | `APP_NAME_OVERRIDES` | Comma-separated `appid=Name` pairs to force specific titles when Steam returns placeholders or incorrect codenames. |
 
 Restart the process after changing `.env`; configuration is read at boot.
 

--- a/example.env
+++ b/example.env
@@ -22,6 +22,9 @@ DEBUG_SQL=0
 # === Discord embed styling ===
 STEAM_EMBED_COLOR=#171A21
 
+# Override problematic Steam app names (comma-separated appid=Name)
+APP_NAME_OVERRIDES=
+
 # === Sales (Steam store search) ===
 # Sort options depend on Steam; "Discount_DESC" is good for deals
 SALES_SORT_BY=Discount_DESC

--- a/src/steam/api.js
+++ b/src/steam/api.js
@@ -10,6 +10,7 @@ const {
   STEAM_API_KEY,
   SCHEMA_TTL_MS,
   RARITY_TTL_MS,
+  APP_NAME_OVERRIDES,
 } = require('../config');
 
 const PLACEHOLDER_REFRESH_MS = 24 * 60 * 60 * 1000;
@@ -184,6 +185,9 @@ async function fetchAppNameFromStore(appid) {
  * missing, placeholder-like, or old so embeds can recover from stale schema entries.
  */
 async function getAppNameCached(appid, { refreshIfPlaceholder = false } = {}) {
+  const override = APP_NAME_OVERRIDES?.[appid];
+  if (override) return override;
+
   const { name: cachedStoreName, stale: storeStale } = await getCachedAppName(appid);
   if (cachedStoreName && !storeStale) return cachedStoreName;
 


### PR DESCRIPTION
## Summary
- allow environment-defined overrides for Steam app names when API responses return placeholders or codenames
- apply overrides ahead of cached/store names for announcements and warn on malformed entries
- document the override option in the README and example environment file

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c7de4cba4832699ce37faff47550e)